### PR TITLE
[CLOUD-1016] add valid_before/after to google_service_account_key

### DIFF
--- a/google/data_source_google_service_account_key.go
+++ b/google/data_source_google_service_account_key.go
@@ -2,10 +2,10 @@ package google
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"regexp"
 )
 
 func dataSourceGoogleServiceAccountKey() *schema.Resource {
@@ -74,6 +74,12 @@ func dataSourceGoogleServiceAccountKeyRead(d *schema.ResourceData, meta interfac
 	}
 	if err := d.Set("public_key", sak.PublicKeyData); err != nil {
 		return fmt.Errorf("Error setting public_key: %s", err)
+	}
+	if err := d.Set("valid_before", sak.ValidBeforeTime); err != nil {
+		return fmt.Errorf("Error setting valid_before: %s", err)
+	}
+	if err := d.Set("valid_after", sak.ValidAfterTime); err != nil {
+		return fmt.Errorf("Error setting valid_after: %s", err)
 	}
 
 	return nil

--- a/google/resource_google_service_account_key.go
+++ b/google/resource_google_service_account_key.go
@@ -180,6 +180,12 @@ func resourceGoogleServiceAccountKeyRead(d *schema.ResourceData, meta interface{
 	if err := d.Set("public_key", sak.PublicKeyData); err != nil {
 		return fmt.Errorf("Error setting public_key: %s", err)
 	}
+	if err := d.Set("valid_before", sak.ValidBeforeTime); err != nil {
+		return fmt.Errorf("Error setting valid_before: %s", err)
+	}
+	if err := d.Set("valid_after", sak.ValidAfterTime); err != nil {
+		return fmt.Errorf("Error setting valid_after: %s", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Pretty self-explanatory; when refreshing, `valid_before` and `valid_after` are not set even though we have the information from the previous request.  This just sets them.